### PR TITLE
make the returning statement explicit

### DIFF
--- a/machines/sequelizer.js
+++ b/machines/sequelizer.js
@@ -812,6 +812,16 @@ module.exports = {
           buildQueryPiece('offset', expr.value, options.query);
           break;
 
+        case 'RETURNING':
+          // If the value is an array, wrap it in an additional array so the
+          // .apply() call works correctly.
+          if (_.isArray(expr.value)) {
+            expr.value = [expr.value];
+          }
+
+          buildQueryPiece('returning', expr.value, options.query);
+          break;
+
         case 'ORDERBY':
 
           // Look ahead and see if the next expression is an Identifier.
@@ -835,9 +845,6 @@ module.exports = {
             // Flatten the expression
             options.expression = fromPairs(options.expression);
             buildQueryPiece('insert', options.expression, options.query);
-
-            // Also add a 'returning' value
-            buildQueryPiece('returning', 'id', options.query);
           }
           break;
 

--- a/test/integration/insert.test.js
+++ b/test/integration/insert.test.js
@@ -13,7 +13,7 @@ describe('Query Generation ::', function() {
         outcomes: [
           {
             dialect: 'postgresql',
-            sql: 'insert into "books" ("title") values ($1) returning "id"',
+            sql: 'insert into "books" ("title") values ($1)',
             bindings: ['Slaughterhouse Five']
           },
           {
@@ -28,8 +28,8 @@ describe('Query Generation ::', function() {
           },
           {
             dialect: 'oracle',
-            sql: 'insert into "books" ("title") values (:1) returning ROWID into :2',
-            bindings: ['Slaughterhouse Five', { 'columnName': 'id' }]
+            sql: 'insert into "books" ("title") values (:1)',
+            bindings: ['Slaughterhouse Five']
           },
           {
             dialect: 'mariadb',
@@ -52,7 +52,7 @@ describe('Query Generation ::', function() {
         outcomes: [
           {
             dialect: 'postgresql',
-            sql: 'insert into "books" ("author", "title") values ($1, $2) returning "id"',
+            sql: 'insert into "books" ("author", "title") values ($1, $2)',
             bindings: ['Kurt Vonnegut', 'Slaughterhouse Five']
           },
           {
@@ -67,8 +67,8 @@ describe('Query Generation ::', function() {
           },
           {
             dialect: 'oracle',
-            sql: 'insert into "books" ("author", "title") values (:1, :2) returning ROWID into :3',
-            bindings: ['Kurt Vonnegut', 'Slaughterhouse Five', { 'columnName': 'id' }]
+            sql: 'insert into "books" ("author", "title") values (:1, :2)',
+            bindings: ['Kurt Vonnegut', 'Slaughterhouse Five']
           },
           {
             dialect: 'mariadb',

--- a/test/integration/returning.test.js
+++ b/test/integration/returning.test.js
@@ -1,0 +1,123 @@
+var Test = require('../support/test-runner');
+
+describe('Query Generation ::', function() {
+  describe('RETURNING statements', function() {
+    it('should generate an returning query', function(done) {
+      Test({
+        query: {
+          insert: {
+            title: 'Slaughterhouse Five'
+          },
+          into: 'books',
+          returning: 'author'
+        },
+        outcomes: [
+          {
+            dialect: 'postgresql',
+            sql: 'insert into "books" ("title") values ($1) returning "author"',
+            bindings: ['Slaughterhouse Five']
+          },
+          {
+            dialect: 'mysql',
+            sql: 'insert into `books` (`title`) values (?)',
+            bindings: ['Slaughterhouse Five']
+          },
+          {
+            dialect: 'sqlite3',
+            sql: 'insert into "books" ("title") values (?)',
+            bindings: ['Slaughterhouse Five']
+          },
+          {
+            dialect: 'oracle',
+            sql: 'insert into "books" ("title") values (:1) returning ROWID into :2',
+            bindings: ['Slaughterhouse Five', { 'columnName': 'author' }]
+          },
+          {
+            dialect: 'mariadb',
+            sql: 'insert into `books` (`title`) values (?)',
+            bindings: ['Slaughterhouse Five']
+          }
+        ]
+      }, done);
+    });
+
+    it('should generate a returning query when using multiple values', function(done) {
+      Test({
+        query: {
+          insert: {
+            title: 'Slaughterhouse Five',
+            author: 'Kurt Vonnegut'
+          },
+          into: 'books',
+          returning: ['author', 'title']
+        },
+        outcomes: [
+          {
+            dialect: 'postgresql',
+            sql: 'insert into "books" ("author", "title") values ($1, $2) returning "author", "title"',
+            bindings: ['Kurt Vonnegut', 'Slaughterhouse Five']
+          },
+          {
+            dialect: 'mysql',
+            sql: 'insert into `books` (`author`, `title`) values (?, ?)',
+            bindings: ['Kurt Vonnegut', 'Slaughterhouse Five']
+          },
+          {
+            dialect: 'sqlite3',
+            sql: 'insert into "books" ("author", "title") values (?, ?)',
+            bindings: ['Kurt Vonnegut', 'Slaughterhouse Five']
+          },
+          {
+            dialect: 'oracle',
+            sql: 'insert into "books" ("author", "title") values (:1, :2) returning ROWID into :3',
+            bindings: ['Kurt Vonnegut', 'Slaughterhouse Five', { 'columnName': 'author:title' }]
+          },
+          {
+            dialect: 'mariadb',
+            sql: 'insert into `books` (`author`, `title`) values (?, ?)',
+            bindings: ['Kurt Vonnegut', 'Slaughterhouse Five']
+          }
+        ]
+      }, done);
+    });
+
+    it('should generate an returning query returning all values if possible', function(done) {
+      Test({
+        query: {
+          insert: {
+            title: 'Slaughterhouse Five'
+          },
+          into: 'books',
+          returning: '*'
+        },
+        outcomes: [
+          {
+            dialect: 'postgresql',
+            sql: 'insert into "books" ("title") values ($1) returning *',
+            bindings: ['Slaughterhouse Five']
+          },
+          {
+            dialect: 'mysql',
+            sql: 'insert into `books` (`title`) values (?)',
+            bindings: ['Slaughterhouse Five']
+          },
+          {
+            dialect: 'sqlite3',
+            sql: 'insert into "books" ("title") values (?)',
+            bindings: ['Slaughterhouse Five']
+          },
+          {
+            dialect: 'oracle',
+            sql: 'insert into "books" ("title") values (:1) returning ROWID into :2',
+            bindings: ['Slaughterhouse Five', { 'columnName': '*' }]
+          },
+          {
+            dialect: 'mariadb',
+            sql: 'insert into `books` (`title`) values (?)',
+            bindings: ['Slaughterhouse Five']
+          }
+        ]
+      }, done);
+    });
+  });
+});

--- a/test/sequelizer/sequelizer.insert.test.js
+++ b/test/sequelizer/sequelizer.insert.test.js
@@ -18,7 +18,7 @@ describe('Sequelizer ::', function() {
       })
       .exec(function(err, result) {
         assert(!err);
-        assert.equal(result.sql, 'insert into "books" ("title") values ($1) returning "id"');
+        assert.equal(result.sql, 'insert into "books" ("title") values ($1)');
         assert.deepEqual(result.bindings, ['Slaughterhouse Five']);
         return done();
       });
@@ -39,7 +39,7 @@ describe('Sequelizer ::', function() {
       })
       .exec(function(err, result) {
         assert(!err, err);
-        assert.equal(result.sql, 'insert into "books" ("author", "title") values ($1, $2) returning "id"');
+        assert.equal(result.sql, 'insert into "books" ("author", "title") values ($1, $2)');
         assert.deepEqual(result.bindings, ['Kurt Vonnegut', 'Slaughterhouse Five']);
         return done();
       });

--- a/test/sequelizer/sequelizer.returning.test.js
+++ b/test/sequelizer/sequelizer.returning.test.js
@@ -1,0 +1,72 @@
+var Sequelizer = require('../../index').sequelizer;
+var analyze = require('../support/analyze');
+var assert = require('assert');
+
+describe('Sequelizer ::', function() {
+  describe('RETURNING statements', function() {
+    it('should generate a simple query with a RETURNING statement', function(done) {
+      var tree = analyze({
+        insert: {
+          title: 'Slaughterhouse Five'
+        },
+        into: 'books',
+        returning: 'author'
+      });
+
+      Sequelizer({
+        dialect: 'postgresql',
+        tree: tree
+      })
+      .exec(function(err, result) {
+        assert(!err);
+        assert.equal(result.sql, 'insert into "books" ("title") values ($1) returning "author"');
+        assert.deepEqual(result.bindings, ['Slaughterhouse Five']);
+        return done();
+      });
+    });
+
+    it('should generate a query with multiple values being returned', function(done) {
+      var tree = analyze({
+        insert: {
+          title: 'Slaughterhouse Five',
+          author: 'Kurt Vonnegut'
+        },
+        into: 'books',
+        returning: ['author', 'title']
+      });
+
+      Sequelizer({
+        dialect: 'postgresql',
+        tree: tree
+      })
+      .exec(function(err, result) {
+        assert(!err, err);
+        assert.equal(result.sql, 'insert into "books" ("author", "title") values ($1, $2) returning "author", "title"');
+        assert.deepEqual(result.bindings, ['Kurt Vonnegut', 'Slaughterhouse Five']);
+        return done();
+      });
+    });
+
+    it('should generate a query with all values being returned', function(done) {
+      var tree = analyze({
+        insert: {
+          title: 'Slaughterhouse Five',
+          author: 'Kurt Vonnegut'
+        },
+        into: 'books',
+        returning: '*'
+      });
+
+      Sequelizer({
+        dialect: 'postgresql',
+        tree: tree
+      })
+      .exec(function(err, result) {
+        assert(!err, err);
+        assert.equal(result.sql, 'insert into "books" ("author", "title") values ($1, $2) returning *');
+        assert.deepEqual(result.bindings, ['Kurt Vonnegut', 'Slaughterhouse Five']);
+        return done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Before it was relying on the primary key being `id` which isn't correct. This makes the returning clause explicit.
