### PR TITLE
[patch] Fix issue with nested "IN" and "NIN"

### DIFF
--- a/lib/sequelizer.js
+++ b/lib/sequelizer.js
@@ -172,7 +172,7 @@ module.exports = function sequelizer(options) {
 
         // Check for any modifiers and combinators in this expression piece
         var modifiers = checkForModifiers(_expr, {
-          strip: ['NOT', 'AND', 'OR']
+          strip: ['NOT', 'AND', 'OR', 'IN', 'NOTIN']
         });
 
         // Check the modifier to see what fn to use
@@ -191,9 +191,19 @@ module.exports = function sequelizer(options) {
               }
             }
 
-            if (_.first(modifiers.modifier) === 'NOTIN') {
+            else if (_.first(modifiers.modifier) === 'NOTIN') {
               _fn = 'whereNotIn';
             }
+
+            else if (_.first(modifiers.modifier) === 'IN') {
+              if (modifiers.combinator === 'AND') {
+                _fn = 'whereIn';
+              } else {
+                _fn = 'orWhereIn';
+                modifiers.combinator = 'OR';
+              }
+            }
+
           }
 
           // If we end up with something like [AND, NOT, IN].
@@ -228,7 +238,7 @@ module.exports = function sequelizer(options) {
         if (idx === 0) {
           if (_fn === 'orWhereNotIn') {
             _fn = 'whereNotIn';
-          } else if (_fn === 'orWhereIn') {
+          } else if (_fn === 'whereIn' || _fn === 'orWhereIn') {
             _fn = 'whereIn';
           } else if (_fn === 'orWhereNot') {
             _fn = 'whereNot';

--- a/test/unit/sequelizer/sequelizer.or.test.js
+++ b/test/unit/sequelizer/sequelizer.or.test.js
@@ -93,6 +93,56 @@ describe('Sequelizer ::', function() {
       assert.deepEqual(result.bindings, ['%user0%', 'or test', '%user1', '0', 'or test']);
     });
 
+    it('should generate a query when complex OR statements are used with IN', function() {
+
+      var tree = analyze({
+        select: ['*'],
+        where: {
+          and: [{
+            inviteStatus: 'pending'
+          }, {
+            or: [{
+              entityId: 1,
+              inviteType: 'globalAdmin'
+            }, {
+              entityId: { in : [1] },
+              inviteType: 'localAdmin'
+            }]
+          }]
+        },
+        from: 'users'
+      });
+
+      var result = Sequelizer(tree);
+      assert.equal(result.sql, 'select * from "users" where "inviteStatus" = $1 and (("entityId" = $2 and "inviteType" = $3) or ("entityId" in ($4) and "inviteType" = $5))');
+      assert.deepEqual(result.bindings, ['pending', '1', 'globalAdmin', '1', 'localAdmin']);
+    });
+
+    it('should generate a query when complex OR statements are used with NOT IN', function() {
+
+      var tree = analyze({
+        select: ['*'],
+        where: {
+          and: [{
+            inviteStatus: 'pending'
+          }, {
+            or: [{
+              entityId: 1,
+              inviteType: 'globalAdmin'
+            }, {
+              entityId: { nin : [1] },
+              inviteType: 'localAdmin'
+            }]
+          }]
+        },
+        from: 'users'
+      });
+
+      var result = Sequelizer(tree);
+      assert.equal(result.sql, 'select * from "users" where "inviteStatus" = $1 and (("entityId" = $2 and "inviteType" = $3) or ("entityId" not in ($4) and "inviteType" = $5))');
+      assert.deepEqual(result.bindings, ['pending', '1', 'globalAdmin', '1', 'localAdmin']);
+    });
+
     it('should generate a query when complex multi-level nesting OR statements are used', function() {
       var tree = analyze({
         select: ['*'],

--- a/test/unit/sequelizer/sequelizer.where.not.in.test.js
+++ b/test/unit/sequelizer/sequelizer.where.not.in.test.js
@@ -24,6 +24,29 @@ describe('Sequelizer ::', function() {
       assert.deepEqual(result.bindings, ['1', '2', '3']);
     });
 
+    it('should generate a query when used in a conjunction', function() {
+      var tree = analyze({
+        select: ['name'],
+        from: 'users',
+        where: {
+          and: [
+            {
+              id: {
+                nin: [1, 2, 3]
+              },
+              age: {
+                nin: [30, 40, 50]
+              }
+            }
+          ]
+        }
+      });
+
+      var result = Sequelizer(tree);
+      assert.equal(result.sql, 'select "name" from "users" where ("id" not in ($1, $2, $3) and "age" not in ($4, $5, $6))');
+      assert.deepEqual(result.bindings, ['1', '2', '3', '30', '40', '50']);
+    });
+
     it('should generate a query when in an OR statement', function() {
       var tree = analyze({
         select: ['name'],


### PR DESCRIPTION
Strip 'IN' and 'NOTIN' modifiers out of expressions when building a Knex grouping statement

fixes https://trello.com/c/QuQ3oyTM/173-sails-postgresql100-11-the-operator-sometablesomecolumn-is-not-permitted